### PR TITLE
Add support for overseas holidays

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
       {
         trailingComma: "all",
         semi: false,
-        printWidth: 120,
+        printWidth: 140,
       },
     ],
   },

--- a/README.md
+++ b/README.md
@@ -8,12 +8,22 @@ JavaScript / npm port of [jours-feries-france](https://github.com/AntoineAugusti
 ## Usage
 
 ```js
-import joursFeries from "@socialgouv/jours-feries";
+import { joursFeries, DepartmentId } from "@socialgouv/jours-feries";
 
+// national holidays
 console.log(joursFeries(2018));
 
-// include jours feries alsace-moselle
-console.log(joursFeries(2018, { alsace: true }));
+// national holidays + holidays specific to alsace and moselle
+console.log(joursFeries(2018, { zone: 'alsace-moselle' }));
+// or national holidays + holidays specific to Bas-Rhin department (Alsace)
+console.log(joursFeries(2018, { zone: 'bas-rhin' }));
+console.log(joursFeries(2018, { department: DepartmentId.BAS_RHIN }));
+console.log(joursFeries(2018, { department: 67 }));
+
+// national holidays + holidays specific to Île de la Réunion
+console.log(joursFeries(2018, { department: 974 }));
+console.log(joursFeries(2018, { department: DepartmentId.REUNION }));
+console.log(joursFeries(2018, { zone: "réunion" }));
 ```
 
 ⚠️ Les dates renvoyées sont de vrais objets JavaScript `Date`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,67 @@
-type ReturnTypeFetesMetropole = ReturnType<typeof fetes>
-type ReturnTypeFetesAlsace = ReturnTypeFetesMetropole & ReturnType<typeof fetesAlsace>
-type Zones = "métropole" | "alsace-moselle"
+interface HolidaysCollection {
+  // Common holidays
+  Armistice: Date
+  Ascension: Date
+  Assomption: Date
+  "Fête Nationale": Date
+  "Fête du travail": Date
+  "Jour de l'an": Date
+  "Lundi de Pentecôte": Date
+  "Lundi de Pâques": Date
+  Noël: Date
+  Toussaint: Date
+  "Victoire des alliés": Date
+
+  // Zone specific holidays
+  "Abolition de l'esclavage"?: Date
+  "Arrivée de l'Évangile"?: Date
+  "Fête de l'autonomie"?: Date
+  "Fête de la citoyenneté"?: Date
+  "Fête des morts"?: Date
+  "Fête du Territoire"?: Date
+  "Fête Victor Schoelcher"?: Date
+  "Saint Étienne"?: Date
+  "Saint Pierre Chanel"?: Date
+  "Saints Pierre et Paul"?: Date
+  "Vendredi Saint"?: Date
+}
+
+enum DepartmentId {
+  MOSELLE = 57,
+  BAS_RHIN = 67,
+  HAUT_RHIN = 68,
+  GUADELOUPE = 971,
+  MARTINIQUE = 972,
+  GUYANNE = 973,
+  REUNION = 974,
+  MAYOTTE = 976,
+  SAINT_MARTIN = 978,
+  WALLIS_ET_FUTUNA = 986,
+  POLYNESIE_FRANCAISE = 987,
+  NOUVELLE_CALEDONIE = 988,
+}
+
+type Zone =
+  | "métropole"
+  | "alsace-moselle"
+  | "alsace"
+  | "bas-rhin"
+  | "haut-rhin"
+  | "moselle"
+  | "réunion"
+  | "mayotte"
+  | "guadeloupe"
+  | "guyanne"
+  | "polynésie française"
+  | "martinique"
+  | "wallis et futuna"
+  | "nouvelle calédonie"
+  | "saint martin"
+
+interface JoursFeriesOptions {
+  zone?: Zone
+  department?: DepartmentId | number
+}
 
 const addDays = (date: Date, days: number) => new Date(date.getTime() + days * 24 * 60 * 60 * 1000)
 
@@ -8,9 +69,7 @@ const paques = function (year: number) {
   const a = year % 19
   const century = Math.floor(year / 100)
   const yearsAfterCentury = year % 100
-  const d =
-    (19 * a + century - Math.floor(century / 4) - Math.floor((Math.floor(century - (century + 8) / 25) + 1) / 3) + 15) %
-    30
+  const d = (19 * a + century - Math.floor(century / 4) - Math.floor((Math.floor(century - (century + 8) / 25) + 1) / 3) + 15) % 30
   const e = (32 + 2 * (century % 4) + 2 * Math.floor(yearsAfterCentury / 4) - d - (yearsAfterCentury % 4)) % 7
   const f = d + e - 7 * Math.floor((a + 11 * d + 22 * e) / 451) + 114
   const month = Math.floor(f / 31)
@@ -19,7 +78,15 @@ const paques = function (year: number) {
   return new Date(year, month - 1, day)
 }
 
-const fetes = (year: number) => ({
+const _vendrediSaint = (year: number) => ({
+  "Vendredi Saint": addDays(paques(year), -2),
+})
+
+const _feteVSchoelcher = (year: number) => ({
+  "Fête Victor Schoelcher": new Date(year, 6, 21),
+})
+
+const fetes = (year: number): HolidaysCollection => ({
   Armistice: new Date(year, 10, 11),
   Ascension: addDays(paques(year), 39),
   Assomption: new Date(year, 7, 15),
@@ -33,9 +100,66 @@ const fetes = (year: number) => ({
   "Victoire des alliés": new Date(year, 4, 8),
 })
 
-const fetesAlsace = (year: number) => ({
+const fetesAlsace = (year: number): HolidaysCollection => ({
+  ...fetes(year),
   "Saint Étienne": new Date(year, 11, 26),
-  "Vendredi Saint": addDays(paques(year), -2),
+  ..._vendrediSaint(year),
+})
+
+const fetesReunion = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Abolition de l'esclavage": new Date(year, 11, 20),
+})
+
+const fetesMayotte = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Abolition de l'esclavage": new Date(year, 3, 27),
+})
+
+const fetesGuadeloupe = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Abolition de l'esclavage": new Date(year, 4, 27),
+  ..._feteVSchoelcher(year),
+  ..._vendrediSaint(year),
+})
+
+const fetesGuyanne = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Abolition de l'esclavage": new Date(year, 3, 2),
+  ..._vendrediSaint(year),
+})
+
+const fetesPolynesieFrancaise = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Arrivée de l'Évangile": new Date(year, 2, 5),
+  "Fête de l'autonomie": new Date(year, 5, 29),
+  ..._vendrediSaint(year),
+})
+
+const fetesMartinique = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Abolition de l'esclavage": new Date(year, 4, 22),
+  "Fête des morts": new Date(year, 10, 2),
+  ..._feteVSchoelcher(year),
+  ..._vendrediSaint(year),
+})
+
+const fetesWallisEtFutuna = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Saint Pierre Chanel": new Date(year, 3, 28),
+  "Saints Pierre et Paul": new Date(year, 5, 29),
+  "Fête du Territoire": new Date(year, 6, 29),
+})
+
+const fetesNouvelleCaledonie = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  "Fête de la citoyenneté": new Date(year, 8, 24),
+})
+
+const fetesSaintMartin = (year: number): HolidaysCollection => ({
+  ...fetes(year),
+  ..._feteVSchoelcher(year),
+  "Abolition de l'esclavage": new Date(year, 4, 28),
 })
 
 /**
@@ -44,15 +168,59 @@ const fetesAlsace = (year: number) => ({
  * @param year year you're interested in
  * @param options the zone you're interested in ("métropole" by default)
  */
-function joursFeries(year: number): ReturnTypeFetesMetropole
-function joursFeries(year: number, options: { zone: "métropole" }): ReturnTypeFetesMetropole
-function joursFeries(year: number, options: { zone: "alsace-moselle" }): ReturnTypeFetesAlsace
-function joursFeries(year: number, options: { zone: Zones } = { zone: "métropole" }) {
-  if (options.zone === "alsace-moselle") {
-    return { ...fetes(year), ...fetesAlsace(year) }
-  } else {
-    return fetes(year)
+function joursFeries(year: number, options?: JoursFeriesOptions): HolidaysCollection {
+  const zoneOrDepartment = options?.zone ?? options?.department
+
+  switch (zoneOrDepartment) {
+    case "alsace-moselle":
+    case "alsace":
+    case "moselle":
+    case "bas-rhin":
+    case "haut-rhin":
+    case DepartmentId.MOSELLE:
+    case DepartmentId.BAS_RHIN:
+    case DepartmentId.HAUT_RHIN:
+      return fetesAlsace(year)
+
+    case "guadeloupe":
+    case DepartmentId.GUADELOUPE:
+      return fetesGuadeloupe(year)
+
+    case "guyanne":
+    case DepartmentId.GUYANNE:
+      return fetesGuyanne(year)
+
+    case "martinique":
+    case DepartmentId.MARTINIQUE:
+      return fetesMartinique(year)
+
+    case "mayotte":
+    case DepartmentId.MAYOTTE:
+      return fetesMayotte(year)
+
+    case "nouvelle calédonie":
+    case DepartmentId.NOUVELLE_CALEDONIE:
+      return fetesNouvelleCaledonie(year)
+
+    case "polynésie française":
+    case DepartmentId.POLYNESIE_FRANCAISE:
+      return fetesPolynesieFrancaise(year)
+
+    case "réunion":
+    case DepartmentId.REUNION:
+      return fetesReunion(year)
+
+    case "saint martin":
+    case DepartmentId.SAINT_MARTIN:
+      return fetesSaintMartin(year)
+
+    case "wallis et futuna":
+    case DepartmentId.WALLIS_ET_FUTUNA:
+      return fetesWallisEtFutuna(year)
+
+    default:
+      return fetes(year)
   }
 }
 
-export { joursFeries }
+export { joursFeries, DepartmentId, Zone, HolidaysCollection }

--- a/tests/tests.spec.ts
+++ b/tests/tests.spec.ts
@@ -1,76 +1,294 @@
-import { joursFeries } from "../src/index"
+import { DepartmentId, HolidaysCollection, joursFeries } from "../src/index"
 
-test("should match 2018 results", () =>
-  expect(joursFeries(2018)).toMatchInlineSnapshot(`
-    Object {
-      "Armistice": 2018-11-10T23:00:00.000Z,
-      "Ascension": 2018-05-09T22:00:00.000Z,
-      "Assomption": 2018-08-14T22:00:00.000Z,
-      "Fête Nationale": 2018-07-13T22:00:00.000Z,
-      "Fête du travail": 2018-04-30T22:00:00.000Z,
-      "Jour de l'an": 2017-12-31T23:00:00.000Z,
-      "Lundi de Pentecôte": 2018-05-20T22:00:00.000Z,
-      "Lundi de Pâques": 2018-04-01T22:00:00.000Z,
-      "Noël": 2018-12-24T23:00:00.000Z,
-      "Toussaint": 2018-10-31T23:00:00.000Z,
-      "Victoire des alliés": 2018-05-07T22:00:00.000Z,
-    }
-  `))
+interface FormattedDates {
+  [key: string]: string
+}
 
-test("should match 2020 results", () =>
-  expect(joursFeries(2020)).toMatchInlineSnapshot(`
-    Object {
-      "Armistice": 2020-11-10T23:00:00.000Z,
-      "Ascension": 2020-05-20T22:00:00.000Z,
-      "Assomption": 2020-08-14T22:00:00.000Z,
-      "Fête Nationale": 2020-07-13T22:00:00.000Z,
-      "Fête du travail": 2020-04-30T22:00:00.000Z,
-      "Jour de l'an": 2019-12-31T23:00:00.000Z,
-      "Lundi de Pentecôte": 2020-05-31T22:00:00.000Z,
-      "Lundi de Pâques": 2020-04-12T22:00:00.000Z,
-      "Noël": 2020-12-24T23:00:00.000Z,
-      "Toussaint": 2020-10-31T23:00:00.000Z,
-      "Victoire des alliés": 2020-05-07T22:00:00.000Z,
-    }
-  `))
+const _formatDates = (dates: HolidaysCollection) => {
+  return Object.entries(dates).reduce((final, current) => {
+    final[current[0]] = `${current[1].getFullYear()}-${("0" + (current[1].getMonth() + 1)).slice(-2)}-${("0" + current[1].getDate()).slice(
+      -2,
+    )}`
 
-test("should match 2018 alsace-moselle results", () =>
-  expect(joursFeries(2018, { zone: "alsace-moselle" })).toMatchInlineSnapshot(`
-    Object {
-      "Armistice": 2018-11-10T23:00:00.000Z,
-      "Ascension": 2018-05-09T22:00:00.000Z,
-      "Assomption": 2018-08-14T22:00:00.000Z,
-      "Fête Nationale": 2018-07-13T22:00:00.000Z,
-      "Fête du travail": 2018-04-30T22:00:00.000Z,
-      "Jour de l'an": 2017-12-31T23:00:00.000Z,
-      "Lundi de Pentecôte": 2018-05-20T22:00:00.000Z,
-      "Lundi de Pâques": 2018-04-01T22:00:00.000Z,
-      "Noël": 2018-12-24T23:00:00.000Z,
-      "Saint Étienne": 2018-12-25T23:00:00.000Z,
-      "Toussaint": 2018-10-31T23:00:00.000Z,
-      "Vendredi Saint": 2018-03-29T22:00:00.000Z,
-      "Victoire des alliés": 2018-05-07T22:00:00.000Z,
-    }
-  `))
+    return final
+  }, {} as FormattedDates)
+}
 
-test("should match 2020 alsace-moselle  results", () =>
-  expect(joursFeries(2020, { zone: "alsace-moselle" })).toMatchInlineSnapshot(`
-    Object {
-      "Armistice": 2020-11-10T23:00:00.000Z,
-      "Ascension": 2020-05-20T22:00:00.000Z,
-      "Assomption": 2020-08-14T22:00:00.000Z,
-      "Fête Nationale": 2020-07-13T22:00:00.000Z,
-      "Fête du travail": 2020-04-30T22:00:00.000Z,
-      "Jour de l'an": 2019-12-31T23:00:00.000Z,
-      "Lundi de Pentecôte": 2020-05-31T22:00:00.000Z,
-      "Lundi de Pâques": 2020-04-12T22:00:00.000Z,
-      "Noël": 2020-12-24T23:00:00.000Z,
-      "Saint Étienne": 2020-12-25T23:00:00.000Z,
-      "Toussaint": 2020-10-31T23:00:00.000Z,
-      "Vendredi Saint": 2020-04-09T22:00:00.000Z,
-      "Victoire des alliés": 2020-05-07T22:00:00.000Z,
-    }
-  `))
+const expectedHolidays2018 = {
+  Armistice: "2018-11-11",
+  Ascension: "2018-05-10",
+  Assomption: "2018-08-15",
+  "Fête Nationale": "2018-07-14",
+  "Fête du travail": "2018-05-01",
+  "Jour de l'an": "2018-01-01",
+  "Lundi de Pentecôte": "2018-05-21",
+  "Lundi de Pâques": "2018-04-02",
+  Noël: "2018-12-25",
+  Toussaint: "2018-11-01",
+  "Victoire des alliés": "2018-05-08",
+}
+
+const expectedHolidays2020 = {
+  Armistice: "2020-11-11",
+  Ascension: "2020-05-21",
+  Assomption: "2020-08-15",
+  "Fête Nationale": "2020-07-14",
+  "Fête du travail": "2020-05-01",
+  "Jour de l'an": "2020-01-01",
+  "Lundi de Pentecôte": "2020-06-01",
+  "Lundi de Pâques": "2020-04-13",
+  Noël: "2020-12-25",
+  Toussaint: "2020-11-01",
+  "Victoire des alliés": "2020-05-08",
+}
+
+test("should match 2018 results", () => {
+  expect(_formatDates(joursFeries(2018))).toEqual(expectedHolidays2018)
+  expect(_formatDates(joursFeries(2018, { zone: "métropole" }))).toEqual(expectedHolidays2018)
+  expect(_formatDates(joursFeries(2018, { department: 13 }))).toEqual(expectedHolidays2018)
+})
+
+test("should match 2020 results", () => {
+  expect(_formatDates(joursFeries(2020))).toEqual(expectedHolidays2020)
+  expect(_formatDates(joursFeries(2020, { zone: "métropole" }))).toEqual(expectedHolidays2020)
+  expect(_formatDates(joursFeries(2020, { department: 13 }))).toEqual(expectedHolidays2020)
+})
+
+test("should match 2018 alsace-moselle results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Vendredi Saint": "2018-03-30",
+    "Saint Étienne": "2018-12-26",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "alsace-moselle" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { zone: "alsace" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { zone: "moselle" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.MOSELLE }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 57 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { zone: "bas-rhin" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.BAS_RHIN }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 67 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { zone: "haut-rhin" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.HAUT_RHIN }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 68 }))).toEqual(expected)
+})
+
+test("should match 2020 alsace-moselle results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Vendredi Saint": "2020-04-10",
+    "Saint Étienne": "2020-12-26",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "alsace-moselle" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { zone: "alsace" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { zone: "moselle" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.MOSELLE }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 57 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { zone: "bas-rhin" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.BAS_RHIN }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 67 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { zone: "haut-rhin" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.HAUT_RHIN }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 68 }))).toEqual(expected)
+})
+
+test("should match 2018 réunion results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Abolition de l'esclavage": "2018-12-20",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "réunion" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 974 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.REUNION }))).toEqual(expected)
+})
+
+test("should match 2020 réunion results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Abolition de l'esclavage": "2020-12-20",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "réunion" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 974 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.REUNION }))).toEqual(expected)
+})
+
+test("should match 2018 mayotte results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Abolition de l'esclavage": "2018-04-27",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "mayotte" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 976 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.MAYOTTE }))).toEqual(expected)
+})
+
+test("should match 2020 mayotte results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Abolition de l'esclavage": "2020-04-27",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "mayotte" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 976 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.MAYOTTE }))).toEqual(expected)
+})
+
+test("should match 2018 guadeloupe results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Abolition de l'esclavage": "2018-05-27",
+    "Fête Victor Schoelcher": "2018-07-21",
+    "Vendredi Saint": "2018-03-30",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "guadeloupe" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 971 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.GUADELOUPE }))).toEqual(expected)
+})
+
+test("should match 2020 guadeloupe results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Abolition de l'esclavage": "2020-05-27",
+    "Fête Victor Schoelcher": "2020-07-21",
+    "Vendredi Saint": "2020-04-10",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "guadeloupe" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 971 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.GUADELOUPE }))).toEqual(expected)
+})
+
+test("should match 2018 polynésie française results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Arrivée de l'Évangile": "2018-03-05",
+    "Fête de l'autonomie": "2018-06-29",
+    "Vendredi Saint": "2018-03-30",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "polynésie française" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 987 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.POLYNESIE_FRANCAISE }))).toEqual(expected)
+})
+
+test("should match 2020 polynésie française results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Arrivée de l'Évangile": "2020-03-05",
+    "Fête de l'autonomie": "2020-06-29",
+    "Vendredi Saint": "2020-04-10",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "polynésie française" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 987 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.POLYNESIE_FRANCAISE }))).toEqual(expected)
+})
+
+test("should match 2018 martinique results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Vendredi Saint": "2018-03-30",
+    "Fête Victor Schoelcher": "2018-07-21",
+    "Fête des morts": "2018-11-02",
+    "Abolition de l'esclavage": "2018-05-22",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "martinique" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 972 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.MARTINIQUE }))).toEqual(expected)
+})
+
+test("should match 2020 martinique results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Vendredi Saint": "2020-04-10",
+    "Abolition de l'esclavage": "2020-05-22",
+    "Fête Victor Schoelcher": "2020-07-21",
+    "Fête des morts": "2020-11-02",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "martinique" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 972 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.MARTINIQUE }))).toEqual(expected)
+})
+
+test("should match 2018 wallis et futuna results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Fête du Territoire": "2018-07-29",
+    "Saint Pierre Chanel": "2018-04-28",
+    "Saints Pierre et Paul": "2018-06-29",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "wallis et futuna" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 986 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.WALLIS_ET_FUTUNA }))).toEqual(expected)
+})
+
+test("should match 2020 wallis et futuna results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Fête du Territoire": "2020-07-29",
+    "Saint Pierre Chanel": "2020-04-28",
+    "Saints Pierre et Paul": "2020-06-29",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "wallis et futuna" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 986 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.WALLIS_ET_FUTUNA }))).toEqual(expected)
+})
+
+test("should match 2018 nouvelle calédonie results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Fête de la citoyenneté": "2018-09-24",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "nouvelle calédonie" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 988 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.NOUVELLE_CALEDONIE }))).toEqual(expected)
+})
+
+test("should match 2020 nouvelle calédonie results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Fête de la citoyenneté": "2020-09-24",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "nouvelle calédonie" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 988 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.NOUVELLE_CALEDONIE }))).toEqual(expected)
+})
+
+test("should match 2018 saint martin results", () => {
+  const expected = {
+    ...expectedHolidays2018,
+    "Abolition de l'esclavage": "2018-05-28",
+    "Fête Victor Schoelcher": "2018-07-21",
+  }
+
+  expect(_formatDates(joursFeries(2018, { zone: "saint martin" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: 978 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2018, { department: DepartmentId.SAINT_MARTIN }))).toEqual(expected)
+})
+
+test("should match 2020 saint martin results", () => {
+  const expected = {
+    ...expectedHolidays2020,
+    "Abolition de l'esclavage": "2020-05-28",
+    "Fête Victor Schoelcher": "2020-07-21",
+  }
+
+  expect(_formatDates(joursFeries(2020, { zone: "saint martin" }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: 978 }))).toEqual(expected)
+  expect(_formatDates(joursFeries(2020, { department: DepartmentId.SAINT_MARTIN }))).toEqual(expected)
+})
 
 test("Lundi de Pâques 1954", () => {
   expect(joursFeries(1954)["Lundi de Pâques"]).toMatchInlineSnapshot(`1954-04-18T23:00:00.000Z`)


### PR DESCRIPTION
This PR adds support for overseas holidays.

It also : 

* add support for department number instead of zone name : `{ department: 57 }` is equivalent to `{ zone: "moselle" }`
* simplify return type (should not break anything since return type wasn't exported)
* fix README.md examples : `{ alsace: true }` is not a valid option.